### PR TITLE
Add Azure provider to __init__ and OAUTH_BACKENDS

### DIFF
--- a/loginpass/__init__.py
+++ b/loginpass/__init__.py
@@ -2,6 +2,7 @@ from ._core import register_to
 from ._flask import create_flask_blueprint
 from ._django import create_django_urlpatterns
 from ._consts import version, homepage
+from .azure import Azure, create_azure_backend
 from .google import Google, GoogleServiceAccount
 from .github import GitHub
 from .facebook import Facebook
@@ -22,7 +23,7 @@ from .vk import VK
 
 
 OAUTH_BACKENDS = [
-    Twitter, Facebook, Google, GitHub, Dropbox,
+    Twitter, Facebook, Google, GitHub, Dropbox, Azure,
     Reddit, Gitlab, Slack, Discord, StackOverflow,
     Bitbucket, Strava, Spotify, Yandex, Twitch, VK
 ]
@@ -31,6 +32,7 @@ __all__ = [
     'register_to',
     'create_flask_blueprint',
     'create_django_urlpatterns',
+    'Azure', 'create_azure_backend',
     'Google', 'GoogleServiceAccount',
     'GitHub',
     'Facebook',


### PR DESCRIPTION
The azure provider is missing from the base package and from the
OAUTH_BACKENDS list. It should follow the same pattern as other
packages.