### PR TITLE
Expose OAuthBackend publicly

### DIFF
--- a/loginpass/__init__.py
+++ b/loginpass/__init__.py
@@ -1,4 +1,4 @@
-from ._core import register_to
+from ._core import register_to, OAuthBackend
 from ._flask import create_flask_blueprint
 from ._django import create_django_urlpatterns
 from ._consts import version, homepage
@@ -29,6 +29,7 @@ OAUTH_BACKENDS = [
 
 __all__ = [
     'register_to',
+    'OAuthBackend',
     'create_flask_blueprint',
     'create_django_urlpatterns',
     'Google', 'GoogleServiceAccount',


### PR DESCRIPTION
I need to create a custom backend because for my specific case the
provided ones don't work (using AzureAD v2). I could simply copy and
change the existing provider however the OAuthBackend class is not a
public object. Make it one.