### PR TITLE
Updated __core.py

### DIFF
--- a/loginpass/_core.py
+++ b/loginpass/_core.py
@@ -1,6 +1,6 @@
 from authlib.client import OAuthClient
-from authlib.specs.rfc7519 import jwt, jwk
-from authlib.specs.oidc import CodeIDToken, ImplicitIDToken, UserInfo
+from authlib.jose import jws, jwt
+from authlib.oidc.core import CodeIDToken, ImplicitIDToken, UserInfo
 
 
 class OAuthBackend(OAuthClient):


### PR DESCRIPTION
The new autlib release changes and deprecates some modules/import in the spec submodule as mentioned in the new release [v0.11](https://github.com/lepture/authlib/releases/tag/v0.11) . This leads to the following error on a new installation of loginpass:
`\authlib\specs\__init__.py:3: AuthlibDeprecationWarning: Deprecate "authlib.specs".
It will be compatible before version 1.0.
Read more <https://git.io/fjvpt#file-sp-md>
  deprecate('Deprecate "authlib.specs".', '1.0', 'fjvpt', 'sp')`

Be aware I did not test this yet but I wanted to contribute