### PR TITLE
ORCID login support

### DIFF
--- a/loginpass/__init__.py
+++ b/loginpass/__init__.py
@@ -20,6 +20,7 @@ from .spotify import Spotify
 from .yandex import Yandex
 from .twitch import Twitch
 from .vk import VK
+from .orcid import ORCiD
 
 
 OAUTH_BACKENDS = [
@@ -50,6 +51,7 @@ __all__ = [
     'Yandex',
     'Twitch',
     'VK',
+    'ORCiD',
     'OAUTH_BACKENDS',
 ]
 

--- a/loginpass/orcid.py
+++ b/loginpass/orcid.py
@@ -16,20 +16,20 @@ st
 from ._core import UserInfo, OAuthBackend, parse_id_token
 
 
-_host = 'https://orcid.org/'
-_authorize_url = '{}oauth/authorize'.format(_host)
-_token_url = '{}oauth/token'.format(_host)
+_host = 'https://orcid.org'
+_authorize_url = '{}/oauth/authorize'.format(_host)
+_token_url = '{}/oauth/token'.format(_host)
 
 class ORCiD(OAuthBackend):
     OAUTH_TYPE = '2.0,oidc'
     OAUTH_NAME = 'orcid'
     OAUTH_CONFIG = {
-        'api_base_url': 'https://orcid.org/',
+        'api_base_url': _host,
         'access_token_url': _token_url,
         'authorize_url': _authorize_url,
         'client_kwargs': {'scope': 'openid email profile'},
     }
-    JWK_SET_URL = '{}oauth/jwks'.format(_host)
+    JWK_SET_URL = '{}/oauth/jwks'.format(_host)
 
     def profile(self, **kwargs):
         resp = self.get('userinfo', **kwargs)

--- a/loginpass/orcid.py
+++ b/loginpass/orcid.py
@@ -18,7 +18,7 @@ from ._core import UserInfo, OAuthBackend, parse_id_token
 
 _host = 'https://orcid.org/'
 _authorize_url = '{}oauth/authorize'.format(_host)
-_token_url = '{}oauth2/token'.format(_host)
+_token_url = '{}oauth/token'.format(_host)
 
 class ORCiD(OAuthBackend):
     OAUTH_TYPE = '2.0,oidc'

--- a/loginpass/orcid.py
+++ b/loginpass/orcid.py
@@ -1,0 +1,47 @@
+"""
+st
+    loginpass.orcid
+    ~~~~~~~~~~~~~~~
+
+    Loginpass Backend of ORCiD (https://orcid.org).
+
+    Useful Links:
+
+    - Endpoint signup: https://orcid.org/developer-tools
+
+    :copyright: (c) 2019 by Bryan Newbold
+    :license: AGPLv3+, see LICENSE for more details.
+"""
+
+from ._core import UserInfo, OAuthBackend, parse_id_token
+
+
+_host = 'https://orcid.org/'
+_authorize_url = '{}oauth/authorize'.format(_host)
+_token_url = '{}oauth2/token'.format(_host)
+
+class ORCiD(OAuthBackend):
+    OAUTH_TYPE = '2.0,oidc'
+    OAUTH_NAME = 'orcid'
+    OAUTH_CONFIG = {
+        'api_base_url': 'https://orcid.org/',
+        'access_token_url': _token_url,
+        'authorize_url': _authorize_url,
+        'client_kwargs': {'scope': 'openid email profile'},
+    }
+    JWK_SET_URL = '{}oauth/jwks'.format(_host)
+
+    def profile(self, **kwargs):
+        resp = self.get('userinfo', **kwargs)
+        resp.raise_for_status()
+        data = resp.json()
+        data['orcid'] = data['sub']
+        return UserInfo(data)
+
+    def parse_openid(self, token, nonce=None):
+        return parse_id_token(
+            self, token['id_token'],
+            {"iss": {"values": [_host]}},
+            token.get('access_token'), nonce
+        )
+

--- a/tests/data/orcid_response.json
+++ b/tests/data/orcid_response.json
@@ -1,0 +1,1 @@
+{"sub":"0000-0002-2601-8132","name":"Credit Name","family_name":"Jones","given_name":"Tom"}

--- a/tests/data/orcid_result.json
+++ b/tests/data/orcid_result.json
@@ -1,0 +1,7 @@
+{
+  "sub": "0000-0002-2601-8132",
+  "orcid": "0000-0002-2601-8132",
+  "name": "Credit Name",
+  "family_name": "Jones",
+  "given_name": "Tom"
+}

--- a/tests/test_oauth_backends.py
+++ b/tests/test_oauth_backends.py
@@ -14,6 +14,7 @@ from loginpass import (
     Twitch,
     Gitlab,
     Strava,
+    ORCiD,
 )
 
 
@@ -83,3 +84,6 @@ class TestOAuthBackends(unittest.TestCase):
 
     def test_strava(self):
         self.run_oauth_profile(Strava)
+
+    def test_orcid(self):
+        self.run_oauth_profile(ORCiD)


### PR DESCRIPTION
Adds support for login via ORCID (https://orcid.org), an identifier and login system used in the academic publishing world.

Pretty straight-forward endpoint, with very little additional userinfo. The 'sub' field is the orcid identifier itself, which I duplicate into an "orcid" field. Notably, compared to most endpoints a "preferred_username" is not returned.

As a style thing I wasn't sure what to name the class... "ORCiD" is the brand-preferred acronym, but doesn't feel super appropriate as a python identifier. Perhaps should be "Orcid"?