### PR TITLE
Get the email from github, even when it is private.

### DIFF
--- a/loginpass/github.py
+++ b/loginpass/github.py
@@ -39,4 +39,15 @@ class GitHub(OAuthBackend):
             'picture': data['avatar_url'],
             'website': data.get('blog'),
         }
+
+        # The email can be be None despite the scope being 'user:email'.
+        # That is because a user can choose to make his/her email private.
+        # If that is the case we get all the users emails regardless if private or note
+        # and use the one he/she has marked as `primary`
+        if params.get("email") is None:
+            resp = self.get("user/emails")
+            resp.raise_for_status()
+            data = resp.json()
+            params["email"] = next(email["email"] for email in data if email["primary"])
+
         return UserInfo(params)


### PR DESCRIPTION
Closes #32

Tests are still missing because I would want to make the following changes to the test infrastructure. But wanted to discuss first. I would change the folder layout to:
```
`-- tests/
    `-- data/
        |-- github/
        |   |-- 01_response.json
        |   |-- 02_response.json
        |   `-- result.json
        `-- gitlab/
```
And then use the a file walk to generate `mock.side_effects` in order, so basically this https://github.com/authlib/loginpass/blob/master/tests/test_oauth_backends.py#L35 will turn into something like this `send.side_effects = responses`. Which would allow to easily implement a test for the current change - as it would mean only adding a second response containing the emails. 

What do you think? BTW - I am also happy merging this as is. 