### PR TITLE
Limit version of AuthLib

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     zip_safe=False,
     license='BSD-3-Clause',
     packages=['loginpass'],
-    install_requires=['requests', 'Authlib>=0.11'],
+    install_requires=['requests', 'Authlib>=0.11,<0.13'],
     include_package_data=True,
     tests_require=['nose', 'mock'],
     test_suite='nose.collector',


### PR DESCRIPTION
The current implementation is incompatible with changes introduced AuthLib 0.13. Limit the version during installation, until loginpass is properly redesigned (#45) to support AuthLib 0.13 and up.