### PR TITLE
Correct LinkedIn get_user_email.

### DIFF
--- a/loginpass/linkedin.py
+++ b/loginpass/linkedin.py
@@ -71,7 +71,7 @@ class LinkedIn(OAuthBackend):
         resp.raise_for_status()
         data = resp.json()
 
-        handle = data.get('handle~')
+        handle = data.get('elements', [{}])[0].get('handle~')
         if handle:
             return handle.get('emailAddress')
 


### PR DESCRIPTION
The function used to get LinkedIn user emails expected the wrong response format so always returned None.

Fixes https://github.com/authlib/loginpass/issues/44