### PR TITLE
Correct the Strava scope

### DIFF
--- a/loginpass/strava.py
+++ b/loginpass/strava.py
@@ -26,7 +26,7 @@ class Strava(OAuthBackend):
         'authorize_url': authorize_url,
         'client_kwargs': {
             'response_type': 'code',
-            'scope': 'public',
+            'scope': 'read',
             'token_endpoint_auth_method': 'client_secret_post',
         },
     }


### PR DESCRIPTION
public is not a valid strava scope, as per the documentation 'read' is
used to access public information and likely seems to be the best match.

https://developers.strava.com/docs/authentication/#detailsaboutrequestingaccess