### PR TITLE
Fix protected endpoints for Twitch

### DIFF
--- a/loginpass/twitch.py
+++ b/loginpass/twitch.py
@@ -16,6 +16,17 @@
 from ._core import map_profile_fields
 
 
+def twitch_compliance_fix(session):
+
+    def fix_protected_request(url, headers, data):
+        headers["Client-ID"] = session.client_id
+        return url, headers, data
+
+
+    session.register_compliance_hook(
+        'protected_request', fix_protected_request)
+
+
 def normalize_userinfo(client, data):
     return map_profile_fields(data[0], {
         'sub': 'id',
@@ -39,6 +50,7 @@ class Twitch(object):
         },
         'userinfo_endpoint': 'users',
         'userinfo_compliance_fix': normalize_userinfo,
+        'compliance_fix': twitch_compliance_fix,
     }
 
 

--- a/loginpass/twitch.py
+++ b/loginpass/twitch.py
@@ -17,7 +17,8 @@ from ._core import map_profile_fields
 
 
 def twitch_compliance_fix(session):
-
+    
+    # https://discuss.dev.twitch.tv/t/requiring-oauth-for-helix-twitch-api-endpoints/23916
     def fix_protected_request(url, headers, data):
         headers["Client-ID"] = session.client_id
         return url, headers, data


### PR DESCRIPTION
Twitch.tv now requires the Client-ID used to generate an oauth token to be sent to protected requests along with the token.