### PR TITLE
Fix hard-coded backend

### DIFF
--- a/loginpass/_fastapi.py
+++ b/loginpass/_fastapi.py
@@ -77,7 +77,7 @@ def create_fastapi_routes(backends, oauth, handle_authorize):
         if remote is None:
             raise HTTPException(404)
 
-        redirect_uri = request.url_for("auth", backend="google")
+        redirect_uri = request.url_for("auth", backend=backend)
         conf_key = "{}_AUTHORIZE_PARAMS".format(backend.upper())
         params = oauth.config.get(conf_key, default={})
         return await remote.authorize_redirect(request, redirect_uri, **params)


### PR DESCRIPTION
@zaghaghi This looks like a small oversight? Was your PR working with other backends?

I've  tried this change with `twitter` and #74 but I'm getting the following error. Do you know whats going on?

```
  File "/home/xxx/Documents/socprom/backend/lib/python3.6/site-packages/fastapi/routing.py", line 183, in app
    dependant=dependant, values=values, is_coroutine=is_coroutine
  File "/home/xxx/Documents/socprom/backend/lib/python3.6/site-packages/fastapi/routing.py", line 133, in run_endpoint_function
    return await dependant.call(**values)
  File "/home/xxx/Documents/socprom/backend/lib/python3.6/site-packages/loginpass/_fastapi.py", line 72, in auth
    user_info = await remote.userinfo(token=token)
  File "/home/xxx/Documents/socprom/backend/lib/python3.6/site-packages/authlib/integrations/base_client/async_app.py", line 141, in userinfo
    data = await compliance_fix(self, data)
TypeError: object dict can't be used in 'await' expression

``` 

Edit: Seems that `compliance_fix(self, data)` is returning a dict and the error is triggered. I'm not sure how my changes have caused this - `async` coding is somewhat mysterious to me sometimes. Is this line of code legit normally?