### PR TITLE
[Django] Pass "next" urlparam to authorize endpoint

### DIFF
--- a/loginpass/_django.py
+++ b/loginpass/_django.py
@@ -60,6 +60,7 @@ def create_auth_endpoint(remote, handle_authorize):
 
 
 def create_login_endpoint(remote, backend, auth_route_name):
+    from urllib.parse import urlencode
     from django.conf import settings
     from django.urls import reverse
 
@@ -72,6 +73,9 @@ def create_login_endpoint(remote, backend, auth_route_name):
 
     def login(request):
         redirect_uri = request.build_absolute_uri(reverse(auth_route_name))
+        if 'next' in request.GET:
+            redirect_uri += '?'+urlencode({'next': request.GET['next']})
+
         params = {}
         if authorize_params:
             params.update(authorize_params)

--- a/loginpass/_django.py
+++ b/loginpass/_django.py
@@ -74,6 +74,6 @@ def create_login_endpoint(remote, backend, auth_route_name):
         redirect_uri = request.build_absolute_uri(reverse(auth_route_name))
         params = {}
         if authorize_params:
-            params.udpate(authorize_params)
+            params.update(authorize_params)
         return remote.authorize_redirect(request, redirect_uri, **params)
     return login


### PR DESCRIPTION
When an unauthenticated user accesses a view that requires authentication, the initial redirect to the login endpoint includes a `next` url parameter containing the url for the original view. This change arranges to have that same parameter available to the authorize endpoint so the user can be redirected to the page they originally intended to visit.

Also fixed an unrelated typo.

NB: It is the responsibility of `handle_authorize` to verify that the value of `next` is safe before responding with a redirect.