### PR TITLE
Fix issue #94: Support for authlib 1.0.0

### DIFF
--- a/django_example/website/logins.py
+++ b/django_example/website/logins.py
@@ -1,6 +1,6 @@
 from django.http import HttpResponse, JsonResponse
 from django.urls import include, path
-from authlib.django.client import OAuth
+from authlib.integrations.django_client import OAuth
 from loginpass import create_django_urlpatterns
 from loginpass import Twitter, GitHub, Google
 

--- a/loginpass/_core.py
+++ b/loginpass/_core.py
@@ -20,3 +20,27 @@ def map_profile_fields(data, fields):
             profile[dst] = value
 
     return profile
+
+
+def oauth_register_remote_app(oauth, backend, **kwargs):
+    """Registers & returns an instance of a remote application for 
+    the given ``backend`` service.
+    
+    :param oauth: Authlib OAuth instance
+    :param backend: Backend class to register, e.g GitHub, Twitter etc
+    :param kwargs: Optional, additional, parameters for Authlib OAuth.register()
+    :return: Authlib OAuth remote app
+    """
+    client_cls = oauth.oauth2_client_cls
+    if backend.OAUTH_CONFIG.get('request_token_url'):
+        client_cls = oauth.oauth1_client_cls
+
+    class RemoteApp(backend, client_cls):
+        OAUTH_APP_CONFIG = backend.OAUTH_CONFIG
+    
+    return oauth.register(
+        RemoteApp.NAME,
+        overwrite=True,
+        client_cls=RemoteApp,
+        **kwargs
+    )

--- a/loginpass/_django.py
+++ b/loginpass/_django.py
@@ -1,20 +1,16 @@
+from ._core import oauth_register_remote_app
 
 def create_django_urlpatterns(backend, oauth, handle_authorize):
-    from authlib.integrations.django_client import DjangoRemoteApp
     from django.urls import path
-
-    class RemoteApp(backend, DjangoRemoteApp):
-        OAUTH_APP_CONFIG = backend.OAUTH_CONFIG
 
     token_name = '_loginpass_{}_token'.format(backend.NAME)
     auth_route_name = 'loginpass_{}_auth'.format(backend.NAME)
     login_route_name = 'loginpass_{}_login'.format(backend.NAME)
 
-    remote = oauth.register(
-        backend.NAME,
-        overwrite=True,
+    remote = oauth_register_remote_app(
+        oauth,
+        backend,
         fetch_token=lambda request: getattr(request, token_name, None),
-        client_cls=RemoteApp,
     )
 
     auth = create_auth_endpoint(remote, handle_authorize)

--- a/loginpass/_fastapi.py
+++ b/loginpass/_fastapi.py
@@ -1,3 +1,4 @@
+from ._core import oauth_register_remote_app
 
 def create_fastapi_routes(backends, oauth, handle_authorize):
     """Create a Fastapi routes that you can register it directly to fastapi
@@ -38,7 +39,7 @@ def create_fastapi_routes(backends, oauth, handle_authorize):
     router = APIRouter()
 
     for b in backends:
-        register_to(oauth, b)
+        oauth_register_remote_app(oauth, b)
 
     @router.get("/auth/{backend}")
     async def auth(
@@ -83,12 +84,3 @@ def create_fastapi_routes(backends, oauth, handle_authorize):
         return await remote.authorize_redirect(request, redirect_uri, **params)
 
     return router
-
-
-def register_to(oauth, backend_cls):
-    from authlib.integrations.starlette_client import StarletteRemoteApp
-
-    class RemoteApp(backend_cls, StarletteRemoteApp):
-        OAUTH_APP_CONFIG = backend_cls.OAUTH_CONFIG
-
-    oauth.register(RemoteApp.NAME, overwrite=True, client_cls=RemoteApp)

--- a/loginpass/_flask.py
+++ b/loginpass/_flask.py
@@ -1,3 +1,4 @@
+from ._core import oauth_register_remote_app
 
 def create_flask_blueprint(backends, oauth, handle_authorize):
     """Create a Flask blueprint that you can register it directly to Flask
@@ -35,7 +36,7 @@ def create_flask_blueprint(backends, oauth, handle_authorize):
     from flask import Blueprint, request, url_for, current_app, abort
 
     for b in backends:
-        register_to(oauth, b)
+        oauth_register_remote_app(oauth, b)
 
     bp = Blueprint('loginpass', __name__)
 
@@ -77,12 +78,3 @@ def create_flask_blueprint(backends, oauth, handle_authorize):
         return remote.authorize_redirect(redirect_uri, **params)
 
     return bp
-
-
-def register_to(oauth, backend_cls):
-    from authlib.integrations.flask_client import FlaskOAuth2App
-
-    class RemoteApp(backend_cls, FlaskOAuth2App):
-        OAUTH_APP_CONFIG = backend_cls.OAUTH_CONFIG
-
-    oauth.register(RemoteApp.NAME, overwrite=True, client_cls=RemoteApp)

--- a/loginpass/_flask.py
+++ b/loginpass/_flask.py
@@ -80,9 +80,9 @@ def create_flask_blueprint(backends, oauth, handle_authorize):
 
 
 def register_to(oauth, backend_cls):
-    from authlib.integrations.flask_client import FlaskRemoteApp
+    from authlib.integrations.flask_client import FlaskOAuth2App
 
-    class RemoteApp(backend_cls, FlaskRemoteApp):
+    class RemoteApp(backend_cls, FlaskOAuth2App):
         OAUTH_APP_CONFIG = backend_cls.OAUTH_CONFIG
 
     oauth.register(RemoteApp.NAME, overwrite=True, client_cls=RemoteApp)


### PR DESCRIPTION
Changing `FlaskRemoteApp` to `FlaskOAuth2App` since authlib 1.0.0 was refactored to:
- Remove `FlaskRemoteApp`
- Used `FlaskOAuth2App` instead

This was confirmed to work locally. No longer getting an ImportError exception and worked to auth using Github in the flask_example app.